### PR TITLE
View Binders fix and optimization

### DIFF
--- a/library/src/main/java/com/itude/mobile/mobbl/core/view/bindings/BaseViewBinder.java
+++ b/library/src/main/java/com/itude/mobile/mobbl/core/view/bindings/BaseViewBinder.java
@@ -20,11 +20,12 @@ public abstract class BaseViewBinder implements ViewBinder {
 
         // process children
         for (MBComponent child : state.component.getChildrenOfKind(MBComponent.class)) {
-            state.component = child;
+            BuildState newState = state.clone();
+            newState.component = child;
             Object element = child.getDocument().getValueForPath(child.getAbsoluteDataPath());
-            state.element = (MBElementContainer) (element instanceof MBElement ? element : null);
-            state.parent = (ViewGroup) (result instanceof ViewGroup ? result : state.parent);
-            state.mainViewBinder.bindView(state);
+            newState.element = (MBElementContainer) (element instanceof MBElement ? element : null);
+            newState.parent = (ViewGroup) (result instanceof ViewGroup ? result : state.parent);
+            newState.mainViewBinder.bindView(newState);
         }
 
         return result;

--- a/library/src/main/java/com/itude/mobile/mobbl/core/view/bindings/PageBinder.java
+++ b/library/src/main/java/com/itude/mobile/mobbl/core/view/bindings/PageBinder.java
@@ -11,27 +11,26 @@ import java.util.Map;
 
 public class PageBinder extends BaseViewBinder {
     private final BuildState state;
-    private final Map<String, ViewBinder> childViewBinders;
+    private final MBBasicViewController controller;
+    private final Map<String, ViewBinder> childViewBinders = new HashMap<>();
 
-    public PageBinder(LayoutInflater inflater, MBBasicViewController controller) {
-        controller.getPage().rebuild();
+    public PageBinder(MBBasicViewController controller, ViewGroup rootView) {
 
         state = new BuildState();
         state.element = controller.getPage().getDocument();
         state.component = controller.getPage();
         state.mainViewBinder = this;
         state.context = controller.getActivity();
-        state.inflater = inflater;
+        state.inflater = LayoutInflater.from(state.context);
         state.document = controller.getPage().getDocument();
-        childViewBinders = new HashMap<String, ViewBinder>();
+        state.parent = rootView;
+
+        this.controller = controller;
     }
 
-    public ViewGroup bind(int initialView) {
-        ViewGroup result = (ViewGroup) state.inflater.inflate(initialView, null);
-        state.parent = result;
-
+    public void bind() {
+        controller.getPage().rebuild();
         bindView(state);
-        return result;
     }
 
     public void registerBinding(String componentName, ViewBinder viewBinder) {


### PR DESCRIPTION
- Fixed a bug where having more than 1 panel at the page root made the binding go wrong
- Removed automatic layout inflation behavior from PageBinder. This is now the user's responsibility, the binder only attaches the data to the existing Views
- Made the PageBinder API more like the iOS version (view controller argument in constructor and void parameterless bind function)