### PR TITLE
Added support for code coverage reports.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,11 @@ android {
         lintConfig file("lint.xml")
     }
 
+    buildTypes {
+        debug {
+            testCoverageEnabled = true
+        }
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7


### PR DESCRIPTION
Report can be generated by entering 'gradle createDebugCoverageReport' into the console. The report can then be found at 'library/build/outputs/reports/coverage/debug/index.html'.